### PR TITLE
Add an entry indicating a lack of `cp437` character encoding support 

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,12 @@ You can jump right into editing this file [here](https://github.com/ErichDonGubl
 
 ### Libraries
 
+### Character encodings
+
+* Full support for [`cp437`](https://en.wikipedia.org/wiki/Code_page_437) (see [this issue](https://github.com/ErichDonGubler/not-yet-awesome-rust/issues/21)).
+    * More fully-featured encode/decode libraries like [`encoding`](https://crates.io/crates/encoding) and [`encoding-rs`](https://crates.io/crates/encoding_rs) exist, but don't support this currently.
+    * A [decode-only library](https://github.com/timglabisch/rust_cp437) exists, the development of which seems to have stopped.
+
 #### Data forensics
 
 * ~~Ability to parse `Registry.pol` files from Windows machines~~ -- implemented [by this guy!](https://github.com/ErichDonGubler/not-yet-awesome-rust/issues/16)


### PR DESCRIPTION
See https://github.com/ErichDonGubler/not-yet-awesome-rust/issues/21 for the original issue.